### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security policy
+
+## Supported versions
+
+This repository contains demo code used in the
+[Ops Kubernetes charm tutorial](https://documentation.ubuntu.com/ops/latest/tutorial/).
+It is not production software and carries no security-maintenance commitment.
+Vulnerabilities in this code are addressed on a best-effort basis; there is no
+guaranteed remediation timeline or supported-version matrix.
+
+## Reporting a vulnerability
+
+Despite the limited scope, we still want to know about security issues so we can
+fix them for tutorial users.
+
+The easiest way to report a security issue is through
+[GitHub's security advisory for this project](https://github.com/canonical/api_demo_server/security/advisories/new).
+See [Privately reporting a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)
+for instructions.
+
+You may also send email to security@ubuntu.com. If you want to encrypt your email,
+follow [Canonical's reporting instructions](https://ubuntu.com/security/disclosure-policy#contact-us).
+
+The [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy)
+contains more information about what you can expect when you contact us, and what
+we expect from you.


### PR DESCRIPTION
Canonical's SSDLC requires a SECURITY.md in all repos. The one this PR proposes is similar to the others in Charm Tech repos in terms of reporting options, but it offers no support timeline or timeline for responding to reports, since this is not really a "product".