### PR TITLE
ci: enforce Conventional Commits on PR titles

### DIFF
--- a/.github/check-conventional-pr-title.py
+++ b/.github/check-conventional-pr-title.py
@@ -1,0 +1,84 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Check that a PR title follows the Conventional Commits specification.
+
+Reads the PR title from the PR_TITLE environment variable.
+Exits with a non-zero status and prints an error message if the title is invalid.
+
+Reference: https://www.conventionalcommits.org/en/v1.0.0/
+
+This repo defines a restricted set of commit types and disallows scopes in PR titles.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+_TYPES = frozenset({
+    'chore',
+    'ci',
+    'docs',
+    'feat',
+    'fix',
+    'perf',
+    'refactor',
+    'revert',
+    'test',
+})
+
+# <type>[optional scope][optional !]: <description>
+_PATTERN = re.compile(
+    r'^(?P<type>[A-Za-z]+)'  # lower-case only, but let this be validated by _TYPES
+    r'(?:\((?P<scope>[^()]+)\))?'
+    r'(?P<breaking>!)?'
+    r': '
+    r'(?P<description>.+)$'
+)
+
+
+def _main() -> None:
+    title = os.environ.get('PR_TITLE', '').strip()
+    if not title:
+        print('PR_TITLE environment variable is not set or empty.', file=sys.stderr)
+        sys.exit(1)
+
+    match = _PATTERN.match(title)
+    if not match:
+        print(
+            f'PR title does not follow Conventional Commits format.\n'
+            f'Expected: <type>[!]: <description>\n'
+            f'Got: {title!r}\n'
+            'Read more: https://github.com/canonical/operator/blob/main/CONTRIBUTING.md#pull-requests',
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    scope = match.group('scope')
+    if scope is not None:
+        print(
+            f'Scopes must not be used in PR titles.\n'
+            f'Got: {title!r}\n'
+            'Read more: https://github.com/canonical/operator/blob/main/CONTRIBUTING.md#pull-requests',
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    commit_type = match.group('type')
+    if commit_type not in _TYPES:
+        print(
+            f'Invalid type {commit_type!r} in PR title.\n'
+            f'Valid types: {", ".join(sorted(_TYPES))}\n'
+            f'Got: {title!r}\n'
+            'Read more: https://github.com/canonical/operator/blob/main/CONTRIBUTING.md#pull-requests',
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print(f'OK: {title!r}')
+
+
+if __name__ == '__main__':
+    _main()

--- a/.github/check-conventional-pr-title.py
+++ b/.github/check-conventional-pr-title.py
@@ -53,7 +53,7 @@ def _main() -> None:
             f"PR title does not follow Conventional Commits format.\n"
             f"Expected: <type>[!]: <description>\n"
             f"Got: {title!r}\n"
-            "Read more: https://github.com/canonical/operator/blob/main/CONTRIBUTING.md#pull-requests",
+            "Read more: https://github.com/canonical/api_demo_server/blob/master/CONTRIBUTING.md#pull-requests",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -63,7 +63,7 @@ def _main() -> None:
         print(
             f"Scopes must not be used in PR titles.\n"
             f"Got: {title!r}\n"
-            "Read more: https://github.com/canonical/operator/blob/main/CONTRIBUTING.md#pull-requests",
+            "Read more: https://github.com/canonical/api_demo_server/blob/master/CONTRIBUTING.md#pull-requests",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -74,7 +74,7 @@ def _main() -> None:
             f"Invalid type {commit_type!r} in PR title.\n"
             f"Valid types: {', '.join(sorted(_TYPES))}\n"
             f"Got: {title!r}\n"
-            "Read more: https://github.com/canonical/operator/blob/main/CONTRIBUTING.md#pull-requests",
+            "Read more: https://github.com/canonical/api_demo_server/blob/master/CONTRIBUTING.md#pull-requests",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/.github/check-conventional-pr-title.py
+++ b/.github/check-conventional-pr-title.py
@@ -17,68 +17,70 @@ import os
 import re
 import sys
 
-_TYPES = frozenset({
-    'chore',
-    'ci',
-    'docs',
-    'feat',
-    'fix',
-    'perf',
-    'refactor',
-    'revert',
-    'test',
-})
+_TYPES = frozenset(
+    {
+        "chore",
+        "ci",
+        "docs",
+        "feat",
+        "fix",
+        "perf",
+        "refactor",
+        "revert",
+        "test",
+    }
+)
 
 # <type>[optional scope][optional !]: <description>
 _PATTERN = re.compile(
-    r'^(?P<type>[A-Za-z]+)'  # lower-case only, but let this be validated by _TYPES
-    r'(?:\((?P<scope>[^()]+)\))?'
-    r'(?P<breaking>!)?'
-    r': '
-    r'(?P<description>.+)$'
+    r"^(?P<type>[A-Za-z]+)"  # lower-case only, but let this be validated by _TYPES
+    r"(?:\((?P<scope>[^()]+)\))?"
+    r"(?P<breaking>!)?"
+    r": "
+    r"(?P<description>.+)$"
 )
 
 
 def _main() -> None:
-    title = os.environ.get('PR_TITLE', '').strip()
+    title = os.environ.get("PR_TITLE", "").strip()
     if not title:
-        print('PR_TITLE environment variable is not set or empty.', file=sys.stderr)
+        print("PR_TITLE environment variable is not set or empty.", file=sys.stderr)
         sys.exit(1)
 
     match = _PATTERN.match(title)
     if not match:
         print(
-            f'PR title does not follow Conventional Commits format.\n'
-            f'Expected: <type>[!]: <description>\n'
-            f'Got: {title!r}\n'
-            'Read more: https://github.com/canonical/operator/blob/main/CONTRIBUTING.md#pull-requests',
+            f"PR title does not follow Conventional Commits format.\n"
+            f"Expected: <type>[!]: <description>\n"
+            f"Got: {title!r}\n"
+            "Read more: https://github.com/canonical/operator/blob/main/CONTRIBUTING.md#pull-requests",
             file=sys.stderr,
         )
         sys.exit(1)
 
-    scope = match.group('scope')
+    scope = match.group("scope")
     if scope is not None:
         print(
-            f'Scopes must not be used in PR titles.\n'
-            f'Got: {title!r}\n'
-            'Read more: https://github.com/canonical/operator/blob/main/CONTRIBUTING.md#pull-requests',
+            f"Scopes must not be used in PR titles.\n"
+            f"Got: {title!r}\n"
+            "Read more: https://github.com/canonical/operator/blob/main/CONTRIBUTING.md#pull-requests",
             file=sys.stderr,
         )
         sys.exit(1)
 
-    commit_type = match.group('type')
+    commit_type = match.group("type")
     if commit_type not in _TYPES:
         print(
-            f'Invalid type {commit_type!r} in PR title.\n'
-            f'Valid types: {", ".join(sorted(_TYPES))}\n'
-            f'Got: {title!r}\n'
-            'Read more: https://github.com/canonical/operator/blob/main/CONTRIBUTING.md#pull-requests',
+            f"Invalid type {commit_type!r} in PR title.\n"
+            f"Valid types: {', '.join(sorted(_TYPES))}\n"
+            f"Got: {title!r}\n"
+            "Read more: https://github.com/canonical/operator/blob/main/CONTRIBUTING.md#pull-requests",
             file=sys.stderr,
         )
         sys.exit(1)
 
-    print(f'OK: {title!r}')
+    print(f"OK: {title!r}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     _main()

--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -1,0 +1,21 @@
+---
+name: "Validate PR Title"
+# Ensure that the PR title conforms to the Conventional Commits and our choice of types and scopes, so that library version bumps can be detected automatically
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions: {}
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+      - run: python3 .github/check-conventional-pr-title.py
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+We welcome contributions to this demo server!
+
+Before working on changes, please consider [opening an issue](https://github.com/canonical/api_demo_server/issues) explaining your use case. If you would like to chat with us about your use cases or proposed implementation, you can reach us at [Matrix](https://matrix.to/#/#charmhub-charmdev:ubuntu.com) or [Discourse](https://discourse.charmhub.io/).
+
+# Pull requests
+
+Changes are proposed as [pull requests on GitHub](https://github.com/canonical/api_demo_server/pulls).
+
+Pull requests should have a short title that follows the [conventional commit style](https://www.conventionalcommits.org/en/) using one of these types:
+
+- chore
+- ci
+- docs
+- feat
+- fix
+- perf
+- refactor
+- revert
+- test
+
+Some examples:
+
+- feat: add a new demo endpoint
+- fix!: correct the PostgreSQL connection handling
+- docs: clarify how to build the OCI image
+
+We consider this project too small to use scopes, so we don't use them.
+
+Note that the commit messages to the PR's branch do not need to follow the conventional commit format, as these will be squashed into a single commit to `master` using the PR title as the commit message.
+
+To help us review your changes, please rebase your pull request onto the `master` branch before you request a review. If you need to bring in the latest changes from `master` after the review has started, please use a merge commit.


### PR DESCRIPTION
This PR ports canonical/operator's validate-pr-title.yaml workflow, which validates that pull request titles follow the Conventional Commits specification. PR titles become the squash-merge commit subject, so this keeps the merged history Conventional-Commits clean.

The workflow uses actions/checkout@v6.0.2 (the only action) and runs the local .github/check-conventional-pr-title.py script copied from operator -- no third-party action.

A contribution doc is also added, with a bit of boilerplate plus the section to link to. The readme doesn't really cover this (except perhaps the publish to registry section), and this seems in line with our conventions.