### PR TITLE
fix: patch python-multipart and starlette CVEs

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -22,4 +21,3 @@ jobs:
         uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: high
-          comment-summary-in-pr: on-failure

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -22,4 +22,4 @@ jobs:
       - name: Export locked dependencies (excluding this project)
         run: uv export --frozen --no-emit-project --no-hashes --format requirements-txt -o requirements.txt
       - name: Run pip-audit
-        run: uvx pip-audit -r requirements.txt
+        run: uv pip-audit -r requirements.txt

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -22,4 +22,4 @@ jobs:
       - name: Export locked dependencies (excluding this project)
         run: uv export --frozen --no-emit-project --no-hashes --format requirements-txt -o requirements.txt
       - name: Run pip-audit
-        run: uv pip-audit -r requirements.txt
+        run: uv run pip-audit -r requirements.txt

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
-      - name: Create virtual environment and install dependencies
-        run: uv sync --frozen
+      - name: Export locked dependencies (excluding this project)
+        run: uv export --frozen --no-emit-project --no-hashes --format requirements-txt -o requirements.txt
       - name: Run pip-audit
-        run: uv run pip-audit
+        run: uvx pip-audit -r requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,9 @@ requires-python = ">=3.10"
 dependencies = [
     "fastapi==0.136.1",
     "uvicorn==0.46.0",
-    "python-multipart==0.0.27",
+    "python-multipart==0.0.31",
     "psycopg2-binary==2.9.12",
+    "starlette==1.3.1",
     "starlette_exporter==0.23.0"
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -41,6 +41,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "psycopg2-binary" },
     { name = "python-multipart" },
+    { name = "starlette" },
     { name = "starlette-exporter" },
     { name = "uvicorn" },
 ]
@@ -56,7 +57,8 @@ dev = [
 requires-dist = [
     { name = "fastapi", specifier = "==0.136.1" },
     { name = "psycopg2-binary", specifier = "==2.9.12" },
-    { name = "python-multipart", specifier = "==0.0.27" },
+    { name = "python-multipart", specifier = "==0.0.31" },
+    { name = "starlette", specifier = "==1.3.1" },
     { name = "starlette-exporter", specifier = "==0.23.0" },
     { name = "uvicorn", specifier = "==0.46.0" },
 ]
@@ -721,11 +723,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.27"
+version = "0.0.31"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/7e/9b35ad8f3d9ca680f7c87a88f19612fdd8da9796c4d3b46e560ac79dcc4a/python_multipart-0.0.31.tar.gz", hash = "sha256:fc631183bb13e56db3158a4909908dfb2e23565286744e798241e63750e5d680", size = 46689, upload-time = "2026-06-04T08:27:49.014Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/1e/7f7f299527a5a8ad90acd5f2f78dfa6c8495c6301a3205106ea68a84de96/python_multipart-0.0.31-py3-none-any.whl", hash = "sha256:8408153d68a9773291fc1da39a8b85a50044bddbabd2dd72e9229776b7b15e28", size = 29996, upload-time = "2026-06-04T08:27:47.804Z" },
 ]
 
 [[package]]
@@ -792,15 +794,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.1"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Update dependencies to avoid security issues, and fix a couple of workflow uses at the same time:

- Bump `python-multipart` 0.0.27 → 0.0.31 (GHSA-5rvq-cxj2-64vf; CVE-2026-53538/9/40).
- Pin `starlette` 1.0.1 → 1.3.1 (CVE-2026-48817/8, CVE-2026-54282/3). It's transitive via FastAPI but needs an explicit pin to escape the vulnerable range.
- `dependency-review` workflow: drop `comment-summary-in-pr` (and the unused `pull-requests: write` permission). Fork PRs always get a read-only `GITHUB_TOKEN` regardless of declared permissions, so the comment never posts and the action logs a misleading permissions warning. The summary still renders on the workflow run page.
- `security` (pip-audit) workflow: audit an exported `requirements.txt` instead of the synced venv. Avoids the "Dependency not found on PyPI: api-demo-server" skip warning and drops the need to install the project just to scan its locked deps.