### PR TITLE
ci: fix mistake in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,7 +32,6 @@ jobs:
               }]
             }')
           echo "build-matrix=${matrix}" >> $GITHUB_OUTPUT
-          fi
 
   build:
     needs: [prepare]


### PR DESCRIPTION
I missed a leftover `fi` in the publish workflow. Annoying because I thought I'd tested everything. Apparently not... (I was testing using a copy of the workflow).