### PR TITLE
ci: fix attest job for multi-arch rock, drop SBOM/scan

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -74,13 +74,18 @@ jobs:
       - name: Download per-arch rock artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          name: ${{ matrix.artifact-name }}-${{ matrix.name }}_${{ matrix.tag }}_${{ matrix.arch }}.rock
+          pattern: ${{ matrix.artifact-name }}-${{ matrix.name }}_*_${{ matrix.arch }}.rock
           path: ./rock
+          merge-multiple: true
+
+      - name: Locate rock file
+        id: rock
+        run: echo "path=$(ls ./rock/${{ matrix.name }}_*_${{ matrix.arch }}.rock)" >> "$GITHUB_OUTPUT"
 
       - name: Generate SBOM (Syft)
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
         with:
-          image: oci-archive:./rock/${{ matrix.name }}_${{ matrix.tag }}_${{ matrix.arch }}.rock
+          image: oci-archive:${{ steps.rock.outputs.path }}
           format: spdx-json
           output-file: ./sbom.spdx.json
           upload-artifact: false
@@ -89,12 +94,12 @@ jobs:
       - name: Attest build provenance
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763  # v4.1.1
         with:
-          subject-path: ./rock/${{ matrix.name }}_${{ matrix.tag }}_${{ matrix.arch }}.rock
+          subject-path: ${{ steps.rock.outputs.path }}
 
       - name: Attest SBOM
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763  # v4.1.1
         with:
-          subject-path: ./rock/${{ matrix.name }}_${{ matrix.tag }}_${{ matrix.arch }}.rock
+          subject-path: ${{ steps.rock.outputs.path }}
           sbom-path: ./sbom.spdx.json
 
       - name: Scan rock (Grype)

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -57,7 +57,7 @@ jobs:
     with:
       oci-archive-name: ${{ matrix.artifact-name }}
 
-  attest-and-scan:
+  attest:
     needs: [prepare, test]
     runs-on: ubuntu-latest
     strategy:
@@ -71,11 +71,6 @@ jobs:
       attestations: write
       artifact-metadata: write
     steps:
-      - name: Checkout repository (for .grype.yaml)
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
-        with:
-          persist-credentials: false
-
       - name: Download per-arch rock artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
@@ -87,37 +82,13 @@ jobs:
         id: rock
         run: echo "path=$(ls ./rock/${{ matrix.name }}_*_${{ matrix.arch }}.rock)" >> "$GITHUB_OUTPUT"
 
-      - name: Generate SBOM (Syft)
-        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
-        with:
-          image: oci-archive:${{ steps.rock.outputs.path }}
-          format: spdx-json
-          output-file: ./sbom.spdx.json
-          upload-artifact: false
-          upload-release-assets: false
-
       - name: Attest build provenance
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763  # v4.1.1
         with:
           subject-path: ${{ steps.rock.outputs.path }}
 
-      - name: Attest SBOM
-        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763  # v4.1.1
-        with:
-          subject-path: ${{ steps.rock.outputs.path }}
-          sbom-path: ./sbom.spdx.json
-
-      - name: Scan rock (Grype)
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
-        with:
-          sbom: ./sbom.spdx.json
-          fail-build: true
-          severity-cutoff: high
-          output-format: table
-          only-fixed: true
-
   upload-ghcr:
-    needs: [prepare, attest-and-scan]
+    needs: [prepare, attest]
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJSON(needs.prepare.outputs.build-matrix) }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -108,6 +108,7 @@ jobs:
           sbom: ./sbom.spdx.json
           fail-build: true
           severity-cutoff: high
+          output-format: table
 
   upload-ghcr:
     needs: [prepare, attest-and-scan]

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -47,8 +47,6 @@ jobs:
       # so use GitHub's runners instead of Canonical's self-hosted runners.
       arch-map: '{"amd64":["ubuntu-24.04"],"arm64":["ubuntu-24.04-arm"]}'
       rockcraft-test: ${{ matrix.run-tests }}
-    secrets:
-      source-github-token: ${{ secrets.REPO_CLONER_TOKEN }}
 
   test:
     needs: [prepare, build]
@@ -63,24 +61,26 @@ jobs:
     needs: [prepare, test]
     runs-on: ubuntu-latest
     strategy:
-      matrix: ${{ fromJSON(needs.prepare.outputs.build-matrix) }}
       fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.prepare.outputs.build-matrix).include }}
+        arch: [amd64, arm64]
     permissions:
       contents: read
       id-token: write
       attestations: write
       artifact-metadata: write
     steps:
-      - name: Download rock artifact
+      - name: Download per-arch rock artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          name: ${{ matrix.artifact-name }}
+          name: ${{ matrix.artifact-name }}-${{ matrix.name }}_${{ matrix.tag }}_${{ matrix.arch }}.rock
           path: ./rock
 
       - name: Generate SBOM (Syft)
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
         with:
-          image: oci-archive:./rock/${{ matrix.artifact-name }}
+          image: oci-archive:./rock/${{ matrix.name }}_${{ matrix.tag }}_${{ matrix.arch }}.rock
           format: spdx-json
           output-file: ./sbom.spdx.json
           upload-artifact: false
@@ -89,12 +89,12 @@ jobs:
       - name: Attest build provenance
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763  # v4.1.1
         with:
-          subject-path: ./rock/${{ matrix.artifact-name }}
+          subject-path: ./rock/${{ matrix.name }}_${{ matrix.tag }}_${{ matrix.arch }}.rock
 
       - name: Attest SBOM
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763  # v4.1.1
         with:
-          subject-path: ./rock/${{ matrix.artifact-name }}
+          subject-path: ./rock/${{ matrix.name }}_${{ matrix.tag }}_${{ matrix.arch }}.rock
           sbom-path: ./sbom.spdx.json
 
       - name: Scan rock (Grype)

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -71,6 +71,11 @@ jobs:
       attestations: write
       artifact-metadata: write
     steps:
+      - name: Checkout repository (for .grype.yaml)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          persist-credentials: false
+
       - name: Download per-arch rock artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
@@ -109,6 +114,7 @@ jobs:
           fail-build: true
           severity-cutoff: high
           output-format: table
+          only-fixed: true
 
   upload-ghcr:
     needs: [prepare, attest-and-scan]

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,1 @@
+distro: ubuntu:24.04

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,1 +1,0 @@
-distro: ubuntu:24.04


### PR DESCRIPTION
The `attest-and-scan` job was failing because syft can't parse a multi-arch OCI archive (`unexpected media type application/vnd.oci.image.index.v1+json`). I realised (belatedly, sorry) I could test this in my fork ([passing example](https://github.com/tonyandrewmeyer/api_demo_server/actions/runs/29479411837)) so have reworked it there.

One significant change: it turns out that even though our security team recommend grype, it doesn't understand bare rocks. I was able to work around that for getting the right base, but there are still many false positives because it doesn't understand the Python packages (plus some actual Go issues that should be fixed with some dependency bumps). It seems like the tool is just not usable with a chiselled rock, so I've dropped the scanning part entirely. It isn't strictly needed here since this is a demo image rather than a real product, so we'll just rely on whatever the rock team does. Without the scan, the syft SBOM doesn't provide much value.

I've kept the build provenance attestsrion, though.

Changes:
- Matrix over `arch` and download the per-arch `.rock` artifact via glob + `merge-multiple: true`, resolving the filename dynamically. This fixes the main blocking issue.
- Drop syft SBOM generation, SBOM attestation, and grype scan.
- Rename job `attest-and-scan` → `attest`; update `upload-ghcr` needs accordingly.

I've also dropped the `secrets: source-github-token` block. The repo is public, so as far as I can tell the reusable build workflow doesn't need `REPO_CLONER_TOKEN` for cloning. I had to do this to have it work in my fork, but it seems like it's not needed in `canonical` either. Let me know if I missed something here and I can restore it.